### PR TITLE
Add non-hybrid 2023 Accord and fix CAN Error message

### DIFF
--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -102,7 +102,7 @@ HUDData = namedtuple("HUDData",
 
 def rate_limit_steer(new_steer, last_steer):
   # TODO just hardcoded ramp to min/max in 0.33s for all Honda
-  MAX_DELTA = 3 * DT_CTRL
+  MAX_DELTA = 10 * DT_CTRL
   return clip(new_steer, last_steer - MAX_DELTA, last_steer + MAX_DELTA)
 
 

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -91,7 +91,7 @@ class CarState(CarStateBase):
     super().__init__(CP)
     can_define = CANDefine(DBC[CP.carFingerprint]["pt"])
     self.gearbox_msg = "GEARBOX"
-    if CP.carFingerprint == CAR.HONDA_ACCORD and CP.transmissionType == TransmissionType.cvt:
+    if CP.carFingerprint in (CAR.HONDA_ACCORD, CAR.HONDA_ACCORD_11G) and CP.transmissionType == TransmissionType.cvt:
       self.gearbox_msg = "GEARBOX_15T"
     elif CP.carFingerprint == CAR.HONDA_CRV_6G:
       self.gearbox_msg = "GEARBOX_15T"

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -74,6 +74,9 @@ class CarInterface(CarInterfaceBase):
     # Accord ICE 1.5T CVT has different gearbox message
     if candidate == CAR.HONDA_ACCORD and 0x191 in fingerprint[CAN.pt]:
       ret.transmissionType = TransmissionType.cvt
+    # 11G Accord
+    elif candidate == CAR.HONDA_ACCORD_11G and 0x1A3 not in fingerprint[CAN.pt]:
+      ret.transmissionType = TransmissionType.cvt
     # New Civics can have manual transmission
     elif candidate == CAR.HONDA_CIVIC_2022 and 0x191 not in fingerprint[CAN.pt]:
       ret.transmissionType = TransmissionType.manual
@@ -129,7 +132,7 @@ class CarInterface(CarInterfaceBase):
     elif candidate == CAR.HONDA_ACCORD_11G:
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.18]]
-      
+
     elif candidate == CAR.HONDA_ACCORD:
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]  # TODO: determine if there is a dead zone at the top end
 

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -62,7 +62,6 @@ class HondaFlags(IntFlag):
 
   CANFD_CAR = 128
 
-
 # Car button codes
 class CruiseButtons:
   RES_ACCEL = 4

--- a/selfdrive/car/sunnypilot_carname.json
+++ b/selfdrive/car/sunnypilot_carname.json
@@ -59,6 +59,7 @@
   "Honda Accord 4-Cylinder 2016-17": "HONDA_ACCORD_4CYL_9TH_GEN",
   "Honda Accord 2018-22": "HONDA_ACCORD",
   "Honda Accord Hybrid 2018-22": "HONDA_ACCORD",
+  "Honda Accord 2023-24": "HONDA_ACCORD_11G",
   "Honda Accord Hybrid 2023-24": "HONDA_ACCORD_11G",
   "Honda Civic 2016-18": "HONDA_CIVIC",
   "Honda Civic 2019-21": "HONDA_CIVIC_BOSCH",


### PR DESCRIPTION
**Description**
The bug was caused by the gearbox message for the 1.5T 2023 Honda Accord (the base model) not being present. Fixed by adding the 11th Gen Accord to check for setting the gearbox message (shout out @vanillagorillaa for the tip). The bug resulted in an error message on the display "CAN Error: Check Connections" though there was still some functionality. I also added the non-hybrid accord to the list of vehicles.

**Verification**
Deployed to my 3X and went on a drive. Verified the message was no longer present

**Route**
Route: https://connect.comma.ai/1c0369a871aa063c/00000007--2258504ddb